### PR TITLE
Update README with new conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ A powerful AI extension for VillageSQL Server that adds AI prompt capabilities a
 ### Build from Source
 
 #### Prerequisites
-- VillageSQL Extension SDK (installed at `~/.villagesql` or specified via `VillageSQL_SDK_DIR`)
+- VillageSQL build directory (specified via `VillageSQL_BUILD_DIR`)
 - CMake 3.16 or higher
 - C++17 compatible compiler
 - OpenSSL development libraries (for HTTPS connections)
+
+📚 **Full Documentation**: Visit [villagesql.com/docs](https://villagesql.com/docs) for comprehensive guides on building extensions, architecture details, and more.
 
 #### Build Instructions
 1. Clone the repository:
@@ -30,19 +32,26 @@ A powerful AI extension for VillageSQL Server that adds AI prompt capabilities a
    ```
 
 2. Configure CMake with required paths:
+
+   **Linux:**
    ```bash
    mkdir -p build
    cd build
-   cmake .. -DVillageSQL_SDK_DIR=/path/to/villagesql/sdk -DVEB_INSTALL_DIR=/path/to/veb/directory
+   cmake .. -DVillageSQL_BUILD_DIR=$HOME/build/villagesql
    ```
 
-   **Note**:
-   - `VillageSQL_SDK_DIR`: Path to VillageSQL Extension SDK
-   - `VEB_INSTALL_DIR`: Directory where `make install` will copy the VEB file (optional)
+   **macOS:**
+   ```bash
+   mkdir -p build
+   cd build
+   cmake .. -DVillageSQL_BUILD_DIR=~/build/villagesql
+   ```
+
+   **Note**: `VillageSQL_BUILD_DIR` should point to your VillageSQL build directory.
 
 3. Build the extension:
    ```bash
-   make
+   make -j $(($(getconf _NPROCESSORS_ONLN) - 2))
    ```
 
    This creates the `vsql_ai.veb` package in the build directory.
@@ -67,7 +76,7 @@ INSTALL EXTENSION vsql_ai;
 #### Anthropic Claude
 ```sql
 -- Simple prompt with Claude
-SELECT vsql_ai.ai_prompt(
+SELECT ai_prompt(
     'anthropic',
     'claude-sonnet-4-5-20250929',
     'your-api-key-here',
@@ -78,7 +87,7 @@ SELECT vsql_ai.ai_prompt(
 #### Google Gemini
 ```sql
 -- Simple prompt with Gemini
-SELECT vsql_ai.ai_prompt(
+SELECT ai_prompt(
     'google',
     'gemini-2.5-flash',
     'your-api-key-here',
@@ -98,13 +107,13 @@ INSERT INTO questions VALUES
 -- Get AI responses for multiple questions using Claude
 SET @api_key = 'your-anthropic-api-key';
 SELECT id, question,
-       vsql_ai.ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, question) AS answer
+       ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, question) AS answer
 FROM questions;
 
 -- Or use Gemini
 SET @api_key = 'your-google-api-key';
 SELECT id, question,
-       vsql_ai.ai_prompt('google', 'gemini-2.5-flash', @api_key, question) AS answer
+       ai_prompt('google', 'gemini-2.5-flash', @api_key, question) AS answer
 FROM questions;
 ```
 
@@ -114,7 +123,7 @@ FROM questions;
 ```sql
 -- Generate embedding for text
 SET @api_key = 'your-google-api-key';
-SELECT vsql_ai.create_embed(
+SELECT create_embed(
     'google',
     'text-embedding-004',
     @api_key,
@@ -137,12 +146,12 @@ CREATE TABLE documents (
 SET @api_key = 'your-google-api-key';
 INSERT INTO documents (id, content, embedding)
 VALUES (1, 'Machine learning is a subset of artificial intelligence',
-        vsql_ai.create_embed('google', 'text-embedding-004', @api_key,
+        create_embed('google', 'text-embedding-004', @api_key,
                             'Machine learning is a subset of artificial intelligence'));
 
 -- Query to generate embeddings for multiple documents
 SELECT id, content,
-       vsql_ai.create_embed('google', 'text-embedding-004', @api_key, content) AS embedding
+       create_embed('google', 'text-embedding-004', @api_key, content) AS embedding
 FROM documents;
 ```
 
@@ -182,10 +191,10 @@ Send a prompt to an AI provider and get a response.
 **Examples:**
 ```sql
 -- Anthropic Claude
-SELECT vsql_ai.ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'Hello!');
+SELECT ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'Hello!');
 
 -- Google Gemini
-SELECT vsql_ai.ai_prompt('google', 'gemini-2.5-flash', @api_key, 'Hello!');
+SELECT ai_prompt('google', 'gemini-2.5-flash', @api_key, 'Hello!');
 ```
 
 #### `create_embed(provider, model, api_key, text)`
@@ -202,7 +211,7 @@ Generate text embeddings for vector search and similarity analysis.
 **Examples:**
 ```sql
 -- Google Gemini text embeddings
-SELECT vsql_ai.create_embed('google', 'text-embedding-004', @api_key, 'Machine learning is fascinating');
+SELECT create_embed('google', 'text-embedding-004', @api_key, 'Machine learning is fascinating');
 
 -- Result: [0.02646778, 0.019067757, -0.05332306, ...]
 ```
@@ -221,17 +230,17 @@ SELECT vsql_ai.create_embed('google', 'text-embedding-004', @api_key, 'Machine l
    SET @api_key = 'sk-ant-your-api-key';
 
    -- Use variable in queries
-   SELECT vsql_ai.ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'prompt');
+   SELECT ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'prompt');
    ```
    Session variables keep API keys out of query text and reduce exposure in logs.
 
 2. **Avoid Hardcoded Keys**:
    ```sql
    -- ❌ BAD: Key visible in logs
-   SELECT vsql_ai.ai_prompt('anthropic', 'model', 'sk-ant-12345...', 'prompt');
+   SELECT ai_prompt('anthropic', 'model', 'sk-ant-12345...', 'prompt');
 
    -- ✅ GOOD: Use session variable
-   SELECT vsql_ai.ai_prompt('anthropic', 'model', @api_key, 'prompt');
+   SELECT ai_prompt('anthropic', 'model', @api_key, 'prompt');
    ```
 
 3. **Shell Environment Variables** (Future Enhancement):
@@ -273,8 +282,18 @@ The extension includes comprehensive tests using the MySQL Test Runner (MTR) fra
 
 This method assumes you have successfully run `make install` to install the VEB to your veb_dir.
 
+**Linux:**
 ```bash
-cd ~/build/mysql-test
+cd $HOME/build/villagesql/mysql-test
+perl mysql-test-run.pl --suite=/path/to/vsql-ai/test
+
+# Run individual test
+perl mysql-test-run.pl --suite=/path/to/vsql-ai/test error_handling
+```
+
+**macOS:**
+```bash
+cd ~/build/villagesql/mysql-test
 perl mysql-test-run.pl --suite=/path/to/vsql-ai/test
 
 # Run individual test
@@ -285,8 +304,16 @@ perl mysql-test-run.pl --suite=/path/to/vsql-ai/test error_handling
 
 Use this to test a specific VEB build without installing it first:
 
+**Linux:**
 ```bash
-cd ~/build/mysql-test
+cd $HOME/build/villagesql/mysql-test
+VSQL_AI_VEB=/path/to/vsql-ai/build/vsql_ai.veb \
+  perl mysql-test-run.pl --suite=/path/to/vsql-ai/test
+```
+
+**macOS:**
+```bash
+cd ~/build/villagesql/mysql-test
 VSQL_AI_VEB=/path/to/vsql-ai/build/vsql_ai.veb \
   perl mysql-test-run.pl --suite=/path/to/vsql-ai/test
 ```
@@ -303,8 +330,16 @@ The extension includes live API tests for each provider. Each test will skip liv
    ```
 
 2. **Run the test:**
+
+   **Linux:**
    ```bash
-   cd ~/build/mysql-test
+   cd $HOME/build/villagesql/mysql-test
+   perl mysql-test-run.pl --suite=/path/to/vsql-ai/test ai_prompt_anthropic
+   ```
+
+   **macOS:**
+   ```bash
+   cd ~/build/villagesql/mysql-test
    perl mysql-test-run.pl --suite=/path/to/vsql-ai/test ai_prompt_anthropic
    ```
 
@@ -316,14 +351,30 @@ The extension includes live API tests for each provider. Each test will skip liv
    ```
 
 2. **Run the prompt test:**
+
+   **Linux:**
    ```bash
-   cd ~/build/mysql-test
+   cd $HOME/build/villagesql/mysql-test
+   perl mysql-test-run.pl --suite=/path/to/vsql-ai/test ai_prompt_google
+   ```
+
+   **macOS:**
+   ```bash
+   cd ~/build/villagesql/mysql-test
    perl mysql-test-run.pl --suite=/path/to/vsql-ai/test ai_prompt_google
    ```
 
 3. **Run the embeddings test:**
+
+   **Linux:**
    ```bash
-   cd ~/build/mysql-test
+   cd $HOME/build/villagesql/mysql-test
+   perl mysql-test-run.pl --suite=/path/to/vsql-ai/test create_embed_google
+   ```
+
+   **macOS:**
+   ```bash
+   cd ~/build/villagesql/mysql-test
    perl mysql-test-run.pl --suite=/path/to/vsql-ai/test create_embed_google
    ```
 


### PR DESCRIPTION
Updates README to align with latest villagesql-server conventions:

- Change from VillageSQL_SDK_DIR to VillageSQL_BUILD_DIR for consistency
- Add Linux vs macOS path examples for builds and tests
- Update parallel make commands to use optimal CPU core count
- Add link to villagesql.com/docs documentation
- Update all function examples to show unqualified syntax (per villagesql-server PR #28)
- ai_prompt() and create_embed() can be called without vsql_ai. prefix

Related to villagesql-server PR #28