### PR TITLE
Migrate Actions off Node 20 and pin to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: villagesql/extension-actions/cpp@main
         with:
           extension-name: vsql_ai

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
           (github.event.comment.body == 'recheck' ||
            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
           github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}


### PR DESCRIPTION
GitHub is forcing Node 20 actions to Node 24 on 2026-06-16 (villagesql/villagesql-server#616).

- `actions/checkout` v4 → v6.0.3 (Node 20 → 24), pinned to its commit SHA
- `contributor-assistant/github-action` pinned to its v2.6.1 SHA (its latest release is still Node 20; no Node 24 build exists yet, so it is pinned to an immutable ref rather than bumped)

The C++ build is delegated to `villagesql/extension-actions/cpp@main`; its own Node 20 `upload-artifact` is fixed in that repo (separate PR).

SHAs were resolved from each action's release tag. Validated with `actionlint`.
