### PR TITLE
Support Anthropic extended thinking models in ai_prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,14 @@ FROM documents;
 Currently supported:
 
 #### Anthropic (provider: `anthropic`)
-Claude 4.5 models:
+Claude models:
 - **Claude Sonnet 4.5**: `claude-sonnet-4-5-20250929` (recommended - best for complex agents and coding)
 - **Claude Haiku 4.5**: `claude-haiku-4-5-20251001` (fastest with near-frontier intelligence)
 - **Claude Opus 4.5**: `claude-opus-4-5-20251101` (maximum capability and intelligence)
+- **Claude Sonnet 4.6**: `claude-sonnet-4-6`
+- **Claude Opus 4.7**: `claude-opus-4-7`
+- **Claude Opus 4.8**: `claude-opus-4-8`
+- **Claude Fable 5**: `claude-fable-5`
 
 #### Google (provider: `google`)
 **Generative:**

--- a/mysql-test/r/ai_prompt_anthropic.result
+++ b/mysql-test/r/ai_prompt_anthropic.result
@@ -14,4 +14,7 @@ contains_success
 SELECT LENGTH(ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'Reply with just: OK')) > 0 AS got_response;
 got_response
 1
+SELECT ai_prompt('anthropic', 'claude-fable-5', @api_key, 'Say only the word: SUCCESS') LIKE '%SUCCESS%' AS fable_contains_success;
+fable_contains_success
+1
 UNINSTALL EXTENSION vsql_ai;

--- a/mysql-test/t/ai_prompt_anthropic.test
+++ b/mysql-test/t/ai_prompt_anthropic.test
@@ -26,5 +26,9 @@ SELECT ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'Say only 
 # Verify we got a non-empty response
 SELECT LENGTH(ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'Reply with just: OK')) > 0 AS got_response;
 
+# Extended thinking model test - claude-fable-5 returns a "thinking" content
+# block before the "text" block; verify the text is still extracted
+SELECT ai_prompt('anthropic', 'claude-fable-5', @api_key, 'Say only the word: SUCCESS') LIKE '%SUCCESS%' AS fable_contains_success;
+
 # Cleanup
 UNINSTALL EXTENSION vsql_ai;

--- a/src/ai_providers.cc
+++ b/src/ai_providers.cc
@@ -66,12 +66,23 @@ std::string AnthropicProvider::parse_response(const std::string& response_json,
       return "";
     }
 
-    // Extract response text
+    // Extract response text. Models with extended thinking (e.g.
+    // claude-fable-5) return thinking blocks before the text block, so scan
+    // the content array for "text" blocks rather than only checking the
+    // first element. Concatenate in case the response contains multiple
+    // text blocks.
     if (response.contains("content") && response["content"].is_array() &&
         !response["content"].empty()) {
-      const auto& first_content = response["content"][0];
-      if (first_content.contains("text")) {
-        return first_content["text"].get<std::string>();
+      std::string result;
+      bool found_text = false;
+      for (const auto& block : response["content"]) {
+        if (block.contains("text") && block["text"].is_string()) {
+          result += block["text"].get<std::string>();
+          found_text = true;
+        }
+      }
+      if (found_text) {
+        return result;
       }
     }
 


### PR DESCRIPTION
## Summary

`ai_prompt()` returned `NULL` with the warning `Invalid response format: missing content` when used with Anthropic extended thinking models such as `claude-fable-5`, even though the API call itself succeeded.

These models return a `thinking` content block *before* the `text` block in the `/v1/messages` response:

```json
"content": [
  {"type": "thinking", "thinking": "...", "signature": "..."},
  {"type": "text", "text": "the actual answer"}
]
```

Addresses: https://github.com/villagesql/vsql-ai/issues/21