### PR TITLE
Feature Request: support local:<port> provider syntax for Ollama

### DIFF
--- a/mysql-test/r/ai_prompt_local.result
+++ b/mysql-test/r/ai_prompt_local.result
@@ -1,17 +1,20 @@
 INSTALL EXTENSION vsql_ai;
-SELECT ai_prompt('local', 'llama3.2', '', 'Hello');
-ai_prompt('local', 'llama3.2', '', 'Hello')
+SELECT ai_prompt('local', 'no-such-model-vsql-test', '', 'Hello');
+ai_prompt('local', 'no-such-model-vsql-test', '', 'Hello')
 NULL
 Warnings:
-Warning	3200	VDF error in function 'ai_prompt': model 'llama3.2' not found
+Warning	3200	VDF error in function 'ai_prompt': model 'no-such-model-vsql-test' not found
 SHOW WARNINGS;
 Level	Code	Message
-Warning	3200	VDF error in function 'ai_prompt': model 'llama3.2' not found
+Warning	3200	VDF error in function 'ai_prompt': model 'no-such-model-vsql-test' not found
 # Running live API test
 SELECT ai_prompt('local', @model, '', 'Say only the word: SUCCESS') LIKE '%SUCCESS%' AS contains_success;
 contains_success
 1
 SELECT LENGTH(ai_prompt('local', @model, '', 'Reply with just: OK')) > 0 AS got_response;
 got_response
+1
+SELECT ai_prompt('local:11434', @model, '', 'Say only the word: SUCCESS') LIKE '%SUCCESS%' AS port_contains_success;
+port_contains_success
 1
 UNINSTALL EXTENSION vsql_ai;

--- a/mysql-test/r/error_handling.result
+++ b/mysql-test/r/error_handling.result
@@ -16,6 +16,26 @@ has_result
 0
 Warnings:
 Warning	3200	VDF error in function 'ai_prompt': Unknown provider: invalid_provider
+SELECT ai_prompt('local:abc', 'model', '', 'test') IS NOT NULL AS bad_port_text;
+bad_port_text
+0
+Warnings:
+Warning	3200	VDF error in function 'ai_prompt': Unknown provider: local:abc
+SELECT ai_prompt('local:99999', 'model', '', 'test') IS NOT NULL AS bad_port_range;
+bad_port_range
+0
+Warnings:
+Warning	3200	VDF error in function 'ai_prompt': Unknown provider: local:99999
+SELECT ai_prompt('local:0', 'model', '', 'test') IS NOT NULL AS bad_port_zero;
+bad_port_zero
+0
+Warnings:
+Warning	3200	VDF error in function 'ai_prompt': Unknown provider: local:0
+SELECT ai_prompt('local:', 'model', '', 'test') IS NOT NULL AS bad_port_empty;
+bad_port_empty
+0
+Warnings:
+Warning	3200	VDF error in function 'ai_prompt': Unknown provider: local:
 SELECT ai_prompt('', 'model', 'key', 'test') IS NOT NULL AS empty_provider_result;
 empty_provider_result
 0

--- a/mysql-test/t/ai_prompt_local.test
+++ b/mysql-test/t/ai_prompt_local.test
@@ -8,8 +8,8 @@ if (!$OLLAMA_MODEL) {
 # Install extension
 INSTALL EXTENSION vsql_ai;
 
-# Test with no Ollama running - should produce a warning (connection refused)
-SELECT ai_prompt('local', 'llama3.2', '', 'Hello');
+# Test with a model that is not pulled - should produce a warning
+SELECT ai_prompt('local', 'no-such-model-vsql-test', '', 'Hello');
 SHOW WARNINGS;
 
 # Test with real Ollama
@@ -24,6 +24,9 @@ SELECT ai_prompt('local', @model, '', 'Say only the word: SUCCESS') LIKE '%SUCCE
 
 # Verify we got a non-empty response
 SELECT LENGTH(ai_prompt('local', @model, '', 'Reply with just: OK')) > 0 AS got_response;
+
+# Explicit port syntax - local:<port> targeting the default Ollama port
+SELECT ai_prompt('local:11434', @model, '', 'Say only the word: SUCCESS') LIKE '%SUCCESS%' AS port_contains_success;
 
 # Cleanup
 UNINSTALL EXTENSION vsql_ai;

--- a/mysql-test/t/error_handling.test
+++ b/mysql-test/t/error_handling.test
@@ -12,6 +12,12 @@ SELECT ai_prompt('anthropic', 'model', 'key', NULL) IS NULL AS null_prompt;
 # Test invalid provider - returns error message (not NULL)
 SELECT ai_prompt('invalid_provider', 'model', 'key', 'test') IS NOT NULL AS has_result;
 
+# Test invalid local port syntax - rejected as unknown provider
+SELECT ai_prompt('local:abc', 'model', '', 'test') IS NOT NULL AS bad_port_text;
+SELECT ai_prompt('local:99999', 'model', '', 'test') IS NOT NULL AS bad_port_range;
+SELECT ai_prompt('local:0', 'model', '', 'test') IS NOT NULL AS bad_port_zero;
+SELECT ai_prompt('local:', 'model', '', 'test') IS NOT NULL AS bad_port_empty;
+
 # Test empty strings - returns error message (not NULL)
 SELECT ai_prompt('', 'model', 'key', 'test') IS NOT NULL AS empty_provider_result;
 SELECT ai_prompt('anthropic', '', 'key', 'test') IS NOT NULL AS empty_model_result;

--- a/src/ai_functions.cc
+++ b/src/ai_functions.cc
@@ -29,6 +29,14 @@ using json = nlohmann::json;
 
 namespace vsql_ai {
 
+namespace {
+// The local provider needs no API key; it may carry a port suffix
+// ("local:<port>").
+bool is_local_provider(const std::string& provider_name) {
+  return provider_name == "local" || provider_name.rfind("local:", 0) == 0;
+}
+}  // namespace
+
 // =============================================================================
 // PROMPT Implementation
 // =============================================================================
@@ -60,7 +68,7 @@ void prompt_impl(StringArg provider_arg, StringArg model_arg,
     return;
   }
 
-  if (api_key.empty() && provider_name != "local") {
+  if (api_key.empty() && !is_local_provider(provider_name)) {
     out.warning("API key cannot be empty");
     return;
   }
@@ -126,7 +134,7 @@ void embedding_impl(StringArg provider_arg, StringArg model_arg,
     return;
   }
 
-  if (api_key.empty() && provider_name != "local") {
+  if (api_key.empty() && !is_local_provider(provider_name)) {
     out.warning("API key cannot be empty");
     return;
   }

--- a/src/ai_providers.cc
+++ b/src/ai_providers.cc
@@ -517,12 +517,12 @@ namespace {
 constexpr int kLocalTimeoutSeconds = 300;
 }
 
-LocalProvider::LocalProvider() {}
+LocalProvider::LocalProvider(int port) : port_(port) {}
 
 LocalProvider::~LocalProvider() {}
 
 std::string LocalProvider::get_endpoint() const {
-  return "http://127.0.0.1:11434";
+  return "http://127.0.0.1:" + std::to_string(port_);
 }
 
 std::map<std::string, std::string> LocalProvider::get_headers() const {
@@ -720,6 +720,24 @@ std::unique_ptr<AIProvider> create_provider(const std::string& provider_name) {
 
   if (provider_name == "local") {
     return std::make_unique<LocalProvider>();
+  }
+
+  // "local:<port>" overrides the default Ollama port
+  if (provider_name.rfind("local:", 0) == 0) {
+    const std::string port_str = provider_name.substr(6);
+    if (port_str.empty() ||
+        port_str.find_first_not_of("0123456789") != std::string::npos) {
+      return nullptr;
+    }
+    try {
+      int port = std::stoi(port_str);
+      if (port < 1 || port > 65535) {
+        return nullptr;
+      }
+      return std::make_unique<LocalProvider>(port);
+    } catch (const std::exception&) {
+      return nullptr;
+    }
   }
 
   // Unknown provider

--- a/src/ai_providers.h
+++ b/src/ai_providers.h
@@ -109,10 +109,13 @@ class OpenAIProvider : public AIProvider {
                              std::string* error) const;
 };
 
-// Local provider implementation (Ollama on 127.0.0.1:11434)
+// Local provider implementation (Ollama on 127.0.0.1, port 11434 by
+// default; configurable via the "local:<port>" provider syntax)
 class LocalProvider : public AIProvider {
  public:
-  LocalProvider();
+  static constexpr int kDefaultPort = 11434;
+
+  explicit LocalProvider(int port = kDefaultPort);
   ~LocalProvider() override;
 
   std::string prompt(const std::string& model, const std::string& api_key,
@@ -129,9 +132,12 @@ class LocalProvider : public AIProvider {
                                   const std::string& prompt) const;
   std::string parse_response(const std::string& response_json,
                              std::string* error) const;
+
+  int port_;
 };
 
-// Factory function to create provider by name
+// Factory function to create provider by name. The "local" provider accepts
+// an optional port suffix ("local:<port>") to override the default 11434.
 std::unique_ptr<AIProvider> create_provider(const std::string& provider_name);
 
 }  // namespace vsql_ai


### PR DESCRIPTION
Allow ai_prompt and ai_embedding to target a non-default Ollama port via the provider string (e.g. local:12345), defaulting to 11434 when omitted. Reject invalid port syntax as an unknown provider, and treat local:<port> like local for the empty API key exemption.

Add MTR coverage for port validation and explicit local:11434 usage.

See Issue https://github.com/villagesql/vsql-ai/issues/27