### PR TITLE
docs: update supported Claude models and bump version to 0.0.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,9 +157,12 @@ public:
 ## Supported AI Models
 
 ### Anthropic Claude
-- claude-sonnet-4-5-20250929
-- claude-haiku-4-5-20251001
-- claude-opus-4-5-20251101
+- claude-fable-5 (most capable)
+- claude-opus-5 (recommended default)
+- claude-sonnet-5
+- claude-haiku-4-5
+- Previous generations: claude-opus-4-8, claude-opus-4-7, claude-opus-4-6,
+  claude-opus-4-5-20251101, claude-sonnet-4-6, claude-sonnet-4-5-20250929
 
 ### Google Gemini
 **Generative:**

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ INSTALL EXTENSION vsql_ai;
 -- Simple prompt with Claude
 SELECT ai_prompt(
     'anthropic',
-    'claude-sonnet-4-5-20250929',
+    'claude-opus-5',
     'your-api-key-here',
     'Explain quantum computing in one sentence'
 ) AS response;
@@ -129,7 +129,7 @@ INSERT INTO questions VALUES
 -- Get AI responses for multiple questions using Claude
 SET @api_key = 'your-anthropic-api-key';
 SELECT id, question,
-       ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, question) AS answer
+       ai_prompt('anthropic', 'claude-opus-5', @api_key, question) AS answer
 FROM questions;
 
 -- Or use Gemini
@@ -183,13 +183,14 @@ Currently supported:
 
 #### Anthropic (provider: `anthropic`)
 Claude models:
-- **Claude Sonnet 4.5**: `claude-sonnet-4-5-20250929` (recommended - best for complex agents and coding)
-- **Claude Haiku 4.5**: `claude-haiku-4-5-20251001` (fastest with near-frontier intelligence)
-- **Claude Opus 4.5**: `claude-opus-4-5-20251101` (maximum capability and intelligence)
-- **Claude Sonnet 4.6**: `claude-sonnet-4-6`
-- **Claude Opus 4.7**: `claude-opus-4-7`
-- **Claude Opus 4.8**: `claude-opus-4-8`
-- **Claude Fable 5**: `claude-fable-5`
+- **Claude Fable 5**: `claude-fable-5` (most capable model, for the most demanding reasoning and long-horizon work)
+- **Claude Opus 5**: `claude-opus-5` (recommended - complex agentic coding and enterprise work)
+- **Claude Sonnet 5**: `claude-sonnet-5` (best combination of speed and intelligence)
+- **Claude Haiku 4.5**: `claude-haiku-4-5` (fastest and most cost-effective)
+
+Also supported (previous generations): `claude-opus-4-8`, `claude-opus-4-7`,
+`claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-6`,
+`claude-sonnet-4-5-20250929`.
 
 #### Google (provider: `google`)
 **Generative:**
@@ -225,7 +226,7 @@ Send a prompt to an AI provider and get a response.
 
 **Parameters:**
 - `provider` (STRING): AI provider name ("anthropic", "google", "openai", "local")
-- `model` (STRING): Model identifier (e.g., "claude-sonnet-4-5-20250929", "gemini-2.5-flash", "gpt-4o-mini", "llama3.2")
+- `model` (STRING): Model identifier (e.g., "claude-opus-5", "gemini-2.5-flash", "gpt-4o-mini", "llama3.2")
 - `api_key` (STRING): API key for authentication (use empty string `''` for local provider)
 - `prompt` (STRING): The prompt text to send to the AI
 
@@ -234,7 +235,7 @@ Send a prompt to an AI provider and get a response.
 **Examples:**
 ```sql
 -- Anthropic Claude
-SELECT ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'Hello!');
+SELECT ai_prompt('anthropic', 'claude-opus-5', @api_key, 'Hello!');
 
 -- Google Gemini
 SELECT ai_prompt('google', 'gemini-2.5-flash', @api_key, 'Hello!');
@@ -285,7 +286,7 @@ SELECT ai_embedding('local', 'nomic-embed-text', '', 'Machine learning is fascin
    SET @api_key = 'sk-ant-your-api-key';
 
    -- Use variable in queries
-   SELECT ai_prompt('anthropic', 'claude-sonnet-4-5-20250929', @api_key, 'prompt');
+   SELECT ai_prompt('anthropic', 'claude-opus-5', @api_key, 'prompt');
    ```
    Session variables keep API keys out of query text and reduce exposure in logs.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "vsql_ai",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "AI and embedding functions for VillageSQL",
   "author": "VillageSQL Community",
   "license": "GPL-2.0"


### PR DESCRIPTION
## Summary
- Refresh the Anthropic model list in `README.md` and `AGENTS.md` to the current frontier lineup: **Claude Fable 5**, **Claude Opus 5**, **Claude Sonnet 5**, **Claude Haiku 4.5**. Prior generations (Opus 4.8/4.7/4.6/4.5, Sonnet 4.6/4.5) are still listed as supported.
- Update SQL examples and the function reference to use `claude-opus-5`.
- Bump `manifest.json` to `0.0.5` (0.0.4 was never released; this release carries the 0.0.4 changes too).

No source changes — model IDs are pass-through strings, so nothing in `ai_providers.cc` hardcodes a model list.

## Test plan
- Clean CMake configure + build against the current VillageSQL Extension SDK (Protocol V3, `<villagesql/vsql.h>`): `vsql_ai.veb` builds successfully.
- MTR suite unchanged (the Anthropic tests already cover `claude-fable-5` extended thinking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)