### PR TITLE
fix: contain exceptions at VDF boundary and repair provider parsing bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,9 @@ This extension uses the Protocol V3 stable SDK (`<villagesql/vsql.h>`).
 
 ```cpp
 #include <villagesql/vsql.h>
-using namespace vsql;
 
-void my_function_impl(StringArg arg1, StringArg arg2, StringResult out) {
+void my_function_impl(vsql::StringArg arg1, vsql::StringArg arg2,
+                      vsql::StringResult out) {
     if (arg1.is_null() || arg2.is_null()) { out.set_null(); return; }
     std::string value1(arg1.value());
     // ...
@@ -73,14 +73,23 @@ void my_function_impl(StringArg arg1, StringArg arg2, StringResult out) {
 }
 
 VEF_GENERATE_ENTRY_POINTS(
-    make_extension()
-        .func(make_func<&my_function_impl>("my_function")
-                  .returns(STRING).param(STRING).param(STRING)
+    vsql::make_extension()
+        .func(vsql::make_func<&my_function_impl>("my_function")
+                  .returns(vsql::STRING).param(vsql::STRING).param(vsql::STRING)
                   .buffer_size(65535).build())
 )
 ```
 
+Qualify SDK names with `vsql::` — do not put a `using namespace vsql;` directive at file scope.
+
 Use `out.set_null()` for NULL, `out.warning("msg")` for soft errors (Warning 3200 + NULL), `out.error("msg")` for hard errors. Extension name/version come from `manifest.json`; `make_extension()` takes no args in V3.
+
+**Exception safety is the extension's responsibility.** The SDK does not wrap
+VDF implementations in a try/catch, so an exception escaping an entry point
+crosses the C ABI and terminates the server. This is reachable from ordinary
+SQL — `nlohmann::json::dump()` throws on input that is not valid UTF-8. Every
+entry point must wrap its body in `try` / `catch (const std::exception&)` /
+`catch (...)` and convert the exception into `out.warning(...)`.
 
 ## Testing
 
@@ -146,7 +155,7 @@ public:
 - **AnthropicProvider**: Implements Claude API (messages endpoint)
 - **GoogleProvider**: Implements Gemini API (generateContent, embedContent endpoints)
 - **OpenAIProvider**: Implements OpenAI API (chat/completions, embeddings endpoints)
-- **LocalProvider**: Connects to Ollama on 127.0.0.1:11434 using OpenAI-compatible API (no API key required)
+- **LocalProvider**: Connects to Ollama on 127.0.0.1:11434 — `/api/chat` (native, with `"think": false`) for prompting and the OpenAI-compatible `/v1/embeddings` for embeddings. No API key required; 300-second timeout.
 
 ### Adding a New Provider
 1. Create a new class that inherits from `AIProvider`

--- a/README.md
+++ b/README.md
@@ -155,7 +155,23 @@ SELECT ai_embedding(
 -- Returns: [0.02646778, 0.019067757, -0.05332306, ...]
 ```
 
-#### Using Embeddings with Table Data
+#### Storing Embeddings in a JSON Column
+
+`ai_embedding()` returns the vector as JSON text, but the result carries the
+binary character set. MySQL's JSON functions and `JSON` columns reject it
+directly:
+
+```sql
+-- This fails:
+-- ERROR 3144 (22032): Cannot create a JSON value from a string with
+-- CHARACTER SET 'binary'
+INSERT INTO documents (id, content, embedding)
+VALUES (1, 'Machine learning', ai_embedding('google', 'gemini-embedding-001', @api_key, 'Machine learning'));
+```
+
+Wrap the call in `CONVERT(... USING utf8mb4)` (or `CAST(... AS CHAR)`) whenever
+the value flows into a `JSON` column or a JSON function:
+
 ```sql
 -- Create a table to store documents and their embeddings
 CREATE TABLE documents (
@@ -168,14 +184,16 @@ CREATE TABLE documents (
 SET @api_key = 'your-google-api-key';
 INSERT INTO documents (id, content, embedding)
 VALUES (1, 'Machine learning is a subset of artificial intelligence',
-        ai_embedding('google', 'gemini-embedding-001', @api_key,
-                            'Machine learning is a subset of artificial intelligence'));
+        CONVERT(ai_embedding('google', 'gemini-embedding-001', @api_key,
+                             'Machine learning is a subset of artificial intelligence')
+                USING utf8mb4));
 
--- Query to generate embeddings for multiple documents
-SELECT id, content,
-       ai_embedding('google', 'gemini-embedding-001', @api_key, content) AS embedding
-FROM documents;
+-- Inspect what was stored
+SELECT id, JSON_LENGTH(embedding) AS dimensions FROM documents;
 ```
+
+Plain `TEXT` columns need no conversion — it is only JSON parsing that is
+affected.
 
 ### Supported Providers
 
@@ -304,7 +322,7 @@ SELECT ai_embedding('local', 'nomic-embed-text', '', 'Machine learning is fascin
 ### Network Security
 
 - All API requests use HTTPS with SSL certificate verification
-- Connections timeout after 30 seconds by default
+- Cloud provider connections timeout after 30 seconds; the local (Ollama) provider allows 300 seconds, since local models can be slow to load
 - Failed connections return clear error messages
 
 ## Performance Considerations
@@ -326,6 +344,36 @@ AI providers impose rate limits on API requests:
 - **Anthropic**: Varies by plan (typically 50+ requests/minute)
 - Error messages will indicate rate limit issues
 - Consider spacing out bulk operations
+
+## Known Limitations
+
+**Each call blocks the connection.** Both functions perform a synchronous
+outbound HTTP request from inside the SQL function, holding the server thread
+until the provider responds — up to 30 seconds for cloud providers, 300 for
+local Ollama. Cost scales linearly with row count: `SELECT ai_prompt(...) FROM t`
+issues one request per row, serially. There is no batching or asynchronous
+execution. Materialize results into a column rather than recomputing them per
+query, and raise `max_execution_time` for multi-row statements.
+
+**Embedding output needs an explicit conversion for JSON use.** The returned
+string carries the binary character set, so `JSON_VALID()`, `JSON_LENGTH()`,
+and inserts into a `JSON` column all reject it until you wrap the call in
+`CONVERT(... USING utf8mb4)`. See
+[Storing Embeddings in a JSON Column](#storing-embeddings-in-a-json-column).
+
+**No embeddings from Anthropic.** `ai_embedding('anthropic', ...)` returns a
+warning and NULL — Anthropic publishes no embeddings endpoint. Use `google`,
+`openai`, or `local`.
+
+**Warning text is truncated.** Provider errors are cut to 255 bytes (response
+body excerpts to 100) before being surfaced as a warning. Truncation is
+UTF-8-aware, so a cut never produces invalid text, but long upstream errors
+are not shown in full.
+
+**Errors surface as warnings, not errors.** Every failure path returns SQL
+NULL plus `Warning 3200`. A statement that calls these functions will not
+abort on a provider failure — check for NULL, and inspect `SHOW WARNINGS` to
+see why.
 
 ## Testing
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "vsql_ai",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "AI and embedding functions for VillageSQL",
   "author": "VillageSQL Community",
   "license": "GPL-2.0"

--- a/mysql-test/r/error_handling.result
+++ b/mysql-test/r/error_handling.result
@@ -1,44 +1,65 @@
 INSTALL EXTENSION vsql_ai;
-SELECT ai_prompt(NULL, 'model', 'key', 'prompt') IS NULL AS null_provider;
-null_provider
+SELECT ai_prompt(NULL, 'model', 'key', 'prompt') IS NULL AS null_provider_is_null;
+null_provider_is_null
 1
-SELECT ai_prompt('anthropic', NULL, 'key', 'prompt') IS NULL AS null_model;
-null_model
+SELECT ai_prompt('anthropic', NULL, 'key', 'prompt') IS NULL AS null_model_is_null;
+null_model_is_null
 1
-SELECT ai_prompt('anthropic', 'model', NULL, 'prompt') IS NULL AS null_key;
-null_key
+SELECT ai_prompt('anthropic', 'model', NULL, 'prompt') IS NULL AS null_key_is_null;
+null_key_is_null
 1
-SELECT ai_prompt('anthropic', 'model', 'key', NULL) IS NULL AS null_prompt;
-null_prompt
+SELECT ai_prompt('anthropic', 'model', 'key', NULL) IS NULL AS null_prompt_is_null;
+null_prompt_is_null
 1
-SELECT ai_prompt('invalid_provider', 'model', 'key', 'test') IS NOT NULL AS has_result;
-has_result
-0
+SELECT ai_prompt('invalid_provider', 'model', 'key', 'test') IS NULL AS unknown_provider_is_null;
+unknown_provider_is_null
+1
 Warnings:
 Warning	3200	VDF error in function 'ai_prompt': Unknown provider: invalid_provider
-SELECT ai_prompt('', 'model', 'key', 'test') IS NOT NULL AS empty_provider_result;
-empty_provider_result
-0
+SELECT ai_prompt('', 'model', 'key', 'test') IS NULL AS empty_provider_is_null;
+empty_provider_is_null
+1
 Warnings:
 Warning	3200	VDF error in function 'ai_prompt': Provider name cannot be empty
-SELECT ai_prompt('anthropic', '', 'key', 'test') IS NOT NULL AS empty_model_result;
-empty_model_result
-0
+SELECT ai_prompt('anthropic', '', 'key', 'test') IS NULL AS empty_model_is_null;
+empty_model_is_null
+1
 Warnings:
 Warning	3200	VDF error in function 'ai_prompt': Model name cannot be empty
-SELECT ai_prompt('anthropic', 'model', '', 'test') IS NOT NULL AS empty_key_result;
-empty_key_result
-0
+SELECT ai_prompt('anthropic', 'model', '', 'test') IS NULL AS empty_key_is_null;
+empty_key_is_null
+1
 Warnings:
 Warning	3200	VDF error in function 'ai_prompt': API key cannot be empty
-SELECT ai_prompt('anthropic', 'model', 'key', '') IS NOT NULL AS empty_prompt_result;
-empty_prompt_result
-0
+SELECT ai_prompt('anthropic', 'model', 'key', '') IS NULL AS empty_prompt_is_null;
+empty_prompt_is_null
+1
 Warnings:
 Warning	3200	VDF error in function 'ai_prompt': Prompt text cannot be empty
-SELECT ai_embedding('unknown_provider', 'model', 'key', 'text') IS NOT NULL AS embed_not_implemented;
-embed_not_implemented
-0
+SELECT ai_embedding('google', 'model', 'key', '') IS NULL AS empty_text_is_null;
+empty_text_is_null
+1
+Warnings:
+Warning	3200	VDF error in function 'ai_embedding': Text cannot be empty
+SELECT ai_embedding('unknown_provider', 'model', 'key', 'text') IS NULL AS unknown_provider_embed_is_null;
+unknown_provider_embed_is_null
+1
 Warnings:
 Warning	3200	VDF error in function 'ai_embedding': Unknown provider: unknown_provider
+SELECT ai_prompt('local', 'no-such-model', '', CONVERT(0xFF USING latin1)) IS NULL AS invalid_utf8_prompt_is_null;
+invalid_utf8_prompt_is_null
+1
+Warnings:
+Warning	3200	VDF error in function 'ai_prompt': Internal error: [json.exception.type_error.316] invalid UTF-8 byte at index 0: 0xFF
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3200	VDF error in function 'ai_prompt': Internal error: [json.exception.type_error.316] invalid UTF-8 byte at index 0: 0xFF
+SELECT ai_embedding('local', 'no-such-model', '', CONVERT(0xFF USING latin1)) IS NULL AS invalid_utf8_embed_is_null;
+invalid_utf8_embed_is_null
+1
+Warnings:
+Warning	3200	VDF error in function 'ai_embedding': Internal error: [json.exception.type_error.316] invalid UTF-8 byte at index 0: 0xFF
+SHOW WARNINGS;
+Level	Code	Message
+Warning	3200	VDF error in function 'ai_embedding': Internal error: [json.exception.type_error.316] invalid UTF-8 byte at index 0: 0xFF
 UNINSTALL EXTENSION vsql_ai;

--- a/mysql-test/t/ai_embedding_local.test
+++ b/mysql-test/t/ai_embedding_local.test
@@ -7,7 +7,8 @@ if (!$OLLAMA_EMBED_MODEL) {
 # Install extension
 INSTALL EXTENSION vsql_ai;
 
-# Test with no Ollama running - should produce a warning (connection refused)
+# A model that has not been pulled produces a warning and NULL, carrying
+# Ollama's own "model not found" text.
 SELECT ai_embedding('local', 'nomic-embed-text', '', 'Hello');
 SHOW WARNINGS;
 

--- a/mysql-test/t/ai_prompt_local.test
+++ b/mysql-test/t/ai_prompt_local.test
@@ -8,7 +8,8 @@ if (!$OLLAMA_MODEL) {
 # Install extension
 INSTALL EXTENSION vsql_ai;
 
-# Test with no Ollama running - should produce a warning (connection refused)
+# A model that has not been pulled produces a warning and NULL, carrying
+# Ollama's own "model not found" text.
 SELECT ai_prompt('local', 'llama3.2', '', 'Hello');
 SHOW WARNINGS;
 

--- a/mysql-test/t/error_handling.test
+++ b/mysql-test/t/error_handling.test
@@ -3,23 +3,32 @@
 # Install extension
 INSTALL EXTENSION vsql_ai;
 
-# Test NULL handling - should return NULL
-SELECT ai_prompt(NULL, 'model', 'key', 'prompt') IS NULL AS null_provider;
-SELECT ai_prompt('anthropic', NULL, 'key', 'prompt') IS NULL AS null_model;
-SELECT ai_prompt('anthropic', 'model', NULL, 'prompt') IS NULL AS null_key;
-SELECT ai_prompt('anthropic', 'model', 'key', NULL) IS NULL AS null_prompt;
+# A NULL in any argument position yields NULL with no warning
+SELECT ai_prompt(NULL, 'model', 'key', 'prompt') IS NULL AS null_provider_is_null;
+SELECT ai_prompt('anthropic', NULL, 'key', 'prompt') IS NULL AS null_model_is_null;
+SELECT ai_prompt('anthropic', 'model', NULL, 'prompt') IS NULL AS null_key_is_null;
+SELECT ai_prompt('anthropic', 'model', 'key', NULL) IS NULL AS null_prompt_is_null;
 
-# Test invalid provider - returns error message (not NULL)
-SELECT ai_prompt('invalid_provider', 'model', 'key', 'test') IS NOT NULL AS has_result;
+# A rejected argument yields NULL and raises warning 3200 describing why
+SELECT ai_prompt('invalid_provider', 'model', 'key', 'test') IS NULL AS unknown_provider_is_null;
 
-# Test empty strings - returns error message (not NULL)
-SELECT ai_prompt('', 'model', 'key', 'test') IS NOT NULL AS empty_provider_result;
-SELECT ai_prompt('anthropic', '', 'key', 'test') IS NOT NULL AS empty_model_result;
-SELECT ai_prompt('anthropic', 'model', '', 'test') IS NOT NULL AS empty_key_result;
-SELECT ai_prompt('anthropic', 'model', 'key', '') IS NOT NULL AS empty_prompt_result;
+# Empty arguments are rejected the same way
+SELECT ai_prompt('', 'model', 'key', 'test') IS NULL AS empty_provider_is_null;
+SELECT ai_prompt('anthropic', '', 'key', 'test') IS NULL AS empty_model_is_null;
+SELECT ai_prompt('anthropic', 'model', '', 'test') IS NULL AS empty_key_is_null;
+SELECT ai_prompt('anthropic', 'model', 'key', '') IS NULL AS empty_prompt_is_null;
+SELECT ai_embedding('google', 'model', 'key', '') IS NULL AS empty_text_is_null;
 
-# Test embedding stub - returns error message
-SELECT ai_embedding('unknown_provider', 'model', 'key', 'text') IS NOT NULL AS embed_not_implemented;
+# ai_embedding rejects an unknown provider the same way ai_prompt does
+SELECT ai_embedding('unknown_provider', 'model', 'key', 'text') IS NULL AS unknown_provider_embed_is_null;
+
+# Input that is not valid UTF-8 cannot be serialized into a JSON request body.
+# The resulting exception must be contained and reported as a warning rather
+# than escaping the extension boundary.
+SELECT ai_prompt('local', 'no-such-model', '', CONVERT(0xFF USING latin1)) IS NULL AS invalid_utf8_prompt_is_null;
+SHOW WARNINGS;
+SELECT ai_embedding('local', 'no-such-model', '', CONVERT(0xFF USING latin1)) IS NULL AS invalid_utf8_embed_is_null;
+SHOW WARNINGS;
 
 # Cleanup
 UNINSTALL EXTENSION vsql_ai;

--- a/src/ai_functions.cc
+++ b/src/ai_functions.cc
@@ -168,9 +168,9 @@ namespace {
 // Report an exception as a warning. Building the message allocates, so a
 // second failure (bad_alloc, or anything thrown while unwinding) falls back to
 // a fixed string — out.warning() on a literal cannot throw.
-void report_exception(const std::exception* e, vsql::StringResult out) {
+void report_exception(const std::exception& e, vsql::StringResult out) {
   try {
-    out.warning(truncate_utf8(std::string("Internal error: ") + e->what(),
+    out.warning(truncate_utf8(std::string("Internal error: ") + e.what(),
                               kMaxWarningBytes));
   } catch (...) {
     out.warning("Internal error");
@@ -190,7 +190,7 @@ void prompt_impl(vsql::StringArg provider_arg, vsql::StringArg model_arg,
   try {
     prompt_body(provider_arg, model_arg, api_key_arg, prompt_arg, out);
   } catch (const std::exception& e) {
-    report_exception(&e, out);
+    report_exception(e, out);
   } catch (...) {
     out.warning("Internal error");
   }
@@ -202,7 +202,7 @@ void embedding_impl(vsql::StringArg provider_arg, vsql::StringArg model_arg,
   try {
     embedding_body(provider_arg, model_arg, api_key_arg, text_arg, out);
   } catch (const std::exception& e) {
-    report_exception(&e, out);
+    report_exception(e, out);
   } catch (...) {
     out.warning("Internal error");
   }

--- a/src/ai_functions.cc
+++ b/src/ai_functions.cc
@@ -20,22 +20,21 @@
 #include <string>
 
 #include "ai_providers.h"
-#include "http_client.h"
-#include "nlohmann/json.hpp"
-
-using namespace vsql;
-
-using json = nlohmann::json;
 
 namespace vsql_ai {
 
-// =============================================================================
-// PROMPT Implementation
-// =============================================================================
+// Longest error text passed to out.warning(). Provider messages can be far
+// longer than a useful warning, and the server clamps warnings anyway.
+constexpr size_t kMaxWarningBytes = 255;
 
-void prompt_impl(StringArg provider_arg, StringArg model_arg,
-                 StringArg api_key_arg, StringArg prompt_arg,
-                 StringResult out) {
+namespace {
+
+// Body of ai_prompt. Wrapped by prompt_impl so no exception escapes into the
+// server: JSON serialization throws on input that isn't valid UTF-8, and an
+// exception crossing the extension ABI boundary would terminate the process.
+void prompt_body(vsql::StringArg provider_arg, vsql::StringArg model_arg,
+                 vsql::StringArg api_key_arg, vsql::StringArg prompt_arg,
+                 vsql::StringResult out) {
   // Validate NULL inputs
   if (provider_arg.is_null() || model_arg.is_null() || api_key_arg.is_null() ||
       prompt_arg.is_null()) {
@@ -60,21 +59,22 @@ void prompt_impl(StringArg provider_arg, StringArg model_arg,
     return;
   }
 
-  if (api_key.empty() && provider_name != "local") {
-    out.warning("API key cannot be empty");
-    return;
-  }
-
   if (prompt_text.empty()) {
     out.warning("Prompt text cannot be empty");
     return;
   }
 
-  // Create provider
+  // Resolve the provider before checking the key: an unrecognised name should
+  // be reported as such rather than as a missing key.
   auto provider = create_provider(provider_name);
   if (!provider) {
-    std::string error_msg = "Unknown provider: " + provider_name;
-    out.warning(error_msg);
+    out.warning(
+        truncate_utf8("Unknown provider: " + provider_name, kMaxWarningBytes));
+    return;
+  }
+
+  if (api_key.empty() && provider->requires_api_key()) {
+    out.warning("API key cannot be empty");
     return;
   }
 
@@ -84,24 +84,21 @@ void prompt_impl(StringArg provider_arg, StringArg model_arg,
 
   // Handle errors
   if (!error.empty()) {
-    if (error.length() > 255) {
-      error = error.substr(0, 255);
-    }
-    out.warning(error);
+    out.warning(truncate_utf8(error, kMaxWarningBytes));
     return;
   }
 
-  // Return result (truncates to buffer size automatically)
-  out.set(response);
+  // out.set() clamps with memcpy and would cut a multi-byte sequence, so trim
+  // on a code point boundary first. The view overload borrows from `response`,
+  // which outlives the call, so a response that already fits is not copied.
+  out.set(truncate_utf8_view(response, out.buffer().size()));
 }
 
-// =============================================================================
-// EMBEDDING Implementation
-// =============================================================================
-
-void embedding_impl(StringArg provider_arg, StringArg model_arg,
-                    StringArg api_key_arg, StringArg text_arg,
-                    StringResult out) {
+// Body of ai_embedding. Wrapped by embedding_impl for the same reason as
+// prompt_body above.
+void embedding_body(vsql::StringArg provider_arg, vsql::StringArg model_arg,
+                    vsql::StringArg api_key_arg, vsql::StringArg text_arg,
+                    vsql::StringResult out) {
   // Validate NULL inputs
   if (provider_arg.is_null() || model_arg.is_null() || api_key_arg.is_null() ||
       text_arg.is_null()) {
@@ -126,21 +123,22 @@ void embedding_impl(StringArg provider_arg, StringArg model_arg,
     return;
   }
 
-  if (api_key.empty() && provider_name != "local") {
-    out.warning("API key cannot be empty");
-    return;
-  }
-
   if (text.empty()) {
     out.warning("Text cannot be empty");
     return;
   }
 
-  // Create provider
+  // Resolve the provider before checking the key: an unrecognised name should
+  // be reported as such rather than as a missing key.
   auto provider = create_provider(provider_name);
   if (!provider) {
-    std::string error_msg = "Unknown provider: " + provider_name;
-    out.warning(error_msg);
+    out.warning(
+        truncate_utf8("Unknown provider: " + provider_name, kMaxWarningBytes));
+    return;
+  }
+
+  if (api_key.empty() && provider->requires_api_key()) {
+    out.warning("API key cannot be empty");
     return;
   }
 
@@ -150,16 +148,64 @@ void embedding_impl(StringArg provider_arg, StringArg model_arg,
 
   // Handle errors
   if (!error.empty()) {
-    if (error.length() > 255) {
-      error = error.substr(0, 255);
-    }
-    out.warning(error);
+    out.warning(truncate_utf8(error, kMaxWarningBytes));
     return;
   }
 
-  // Return result (JSON array of floats; truncates to buffer size
-  // automatically)
+  // A clipped JSON array is not a smaller embedding, it is corrupt data.
+  // Refuse rather than return something that parses as a shorter vector.
+  if (embedding_json.size() > out.buffer().size()) {
+    out.warning("Embedding too large for the result buffer");
+    return;
+  }
   out.set(embedding_json);
+}
+
+}  // namespace
+
+namespace {
+
+// Report an exception as a warning. Building the message allocates, so a
+// second failure (bad_alloc, or anything thrown while unwinding) falls back to
+// a fixed string — out.warning() on a literal cannot throw.
+void report_exception(const std::exception* e, vsql::StringResult out) {
+  try {
+    out.warning(truncate_utf8(std::string("Internal error: ") + e->what(),
+                              kMaxWarningBytes));
+  } catch (...) {
+    out.warning("Internal error");
+  }
+}
+
+}  // namespace
+
+// These are the ABI boundary: the SDK does not wrap VDF calls, so an escaping
+// exception terminates the server. They would be marked noexcept to have the
+// compiler enforce that, but make_func's FuncParamTypes has no specialization
+// for noexcept function types, so registration fails to compile. The catch-all
+// below plus report_exception's own fallback are what hold the guarantee.
+void prompt_impl(vsql::StringArg provider_arg, vsql::StringArg model_arg,
+                 vsql::StringArg api_key_arg, vsql::StringArg prompt_arg,
+                 vsql::StringResult out) {
+  try {
+    prompt_body(provider_arg, model_arg, api_key_arg, prompt_arg, out);
+  } catch (const std::exception& e) {
+    report_exception(&e, out);
+  } catch (...) {
+    out.warning("Internal error");
+  }
+}
+
+void embedding_impl(vsql::StringArg provider_arg, vsql::StringArg model_arg,
+                    vsql::StringArg api_key_arg, vsql::StringArg text_arg,
+                    vsql::StringResult out) {
+  try {
+    embedding_body(provider_arg, model_arg, api_key_arg, text_arg, out);
+  } catch (const std::exception& e) {
+    report_exception(&e, out);
+  } catch (...) {
+    out.warning("Internal error");
+  }
 }
 
 }  // namespace vsql_ai
@@ -169,21 +215,21 @@ void embedding_impl(StringArg provider_arg, StringArg model_arg,
 // =============================================================================
 
 VEF_GENERATE_ENTRY_POINTS(
-    make_extension()
-        .func(make_func<&vsql_ai::prompt_impl>("ai_prompt")
-                  .returns(STRING)
-                  .param(STRING)      // provider
-                  .param(STRING)      // model
-                  .param(STRING)      // api_key
-                  .param(STRING)      // prompt
-                  .buffer_size(65535) // Large buffer for AI responses
+    vsql::make_extension()
+        .func(vsql::make_func<&vsql_ai::prompt_impl>("ai_prompt")
+                  .returns(vsql::STRING)
+                  .param(vsql::STRING) // provider
+                  .param(vsql::STRING) // model
+                  .param(vsql::STRING) // api_key
+                  .param(vsql::STRING) // prompt
+                  .buffer_size(65535)  // Large buffer for AI responses
                   .build())
 
-        .func(make_func<&vsql_ai::embedding_impl>("ai_embedding")
-                  .returns(STRING)
-                  .param(STRING) // provider
-                  .param(STRING) // model
-                  .param(STRING) // api_key
-                  .param(STRING) // text
+        .func(vsql::make_func<&vsql_ai::embedding_impl>("ai_embedding")
+                  .returns(vsql::STRING)
+                  .param(vsql::STRING) // provider
+                  .param(vsql::STRING) // model
+                  .param(vsql::STRING) // api_key
+                  .param(vsql::STRING) // text
                   .buffer_size(65535)
                   .build()))

--- a/src/ai_providers.cc
+++ b/src/ai_providers.cc
@@ -23,13 +23,33 @@ using json = nlohmann::json;
 
 namespace vsql_ai {
 
+// Bytes of an unrecognised response body quoted back in an error message.
+constexpr size_t kMaxErrorBodyBytes = 100;
+
+std::string_view truncate_utf8_view(std::string_view text, size_t max_bytes) {
+  if (text.size() <= max_bytes) {
+    return text;
+  }
+
+  // Walk back off any continuation bytes (10xxxxxx) so the cut lands on a
+  // code point boundary.
+  size_t cut = max_bytes;
+  while (cut > 0 &&
+         (static_cast<unsigned char>(text[cut]) & 0xC0) == 0x80) {
+    --cut;
+  }
+
+  return text.substr(0, cut);
+}
+
+std::string truncate_utf8(const std::string& text, size_t max_bytes) {
+  return std::string(truncate_utf8_view(text, max_bytes));
+}
+
 // =============================================================================
 // AnthropicProvider Implementation
 // =============================================================================
 
-AnthropicProvider::AnthropicProvider() {}
-
-AnthropicProvider::~AnthropicProvider() {}
 
 std::string AnthropicProvider::get_endpoint() const {
   return "https://api.anthropic.com";
@@ -71,8 +91,7 @@ std::string AnthropicProvider::parse_response(const std::string& response_json,
     // the content array for "text" blocks rather than only checking the
     // first element. Concatenate in case the response contains multiple
     // text blocks.
-    if (response.contains("content") && response["content"].is_array() &&
-        !response["content"].empty()) {
+    if (response.contains("content") && response["content"].is_array()) {
       std::string result;
       bool found_text = false;
       for (const auto& block : response["content"]) {
@@ -104,8 +123,7 @@ std::string AnthropicProvider::prompt(const std::string& model,
   auto headers = get_headers(api_key);
 
   // Make HTTP request
-  HttpClient client;
-  auto response = client.post(get_endpoint(), "/v1/messages", request_body,
+  auto response = HttpClient::post(get_endpoint(), "/v1/messages", request_body,
                               headers, 30);
 
   // Check for network errors
@@ -125,7 +143,7 @@ std::string AnthropicProvider::prompt(const std::string& model,
       *error = api_error;
     } else {
       *error = "HTTP " + std::to_string(response.status_code) +
-               " - " + response.body.substr(0, 100);
+               " - " + truncate_utf8(response.body, kMaxErrorBodyBytes);
     }
     return "";
   }
@@ -147,11 +165,8 @@ std::string AnthropicProvider::embed(const std::string& model,
 // GoogleProvider Implementation
 // =============================================================================
 
-GoogleProvider::GoogleProvider() {}
 
-GoogleProvider::~GoogleProvider() {}
-
-std::string GoogleProvider::get_endpoint(const std::string& model) const {
+std::string GoogleProvider::get_endpoint() const {
   return "https://generativelanguage.googleapis.com";
 }
 
@@ -194,7 +209,7 @@ std::string GoogleProvider::parse_response(const std::string& response_json,
         if (content.contains("parts") && content["parts"].is_array() &&
             !content["parts"].empty()) {
           const auto& first_part = content["parts"][0];
-          if (first_part.contains("text")) {
+          if (first_part.contains("text") && first_part["text"].is_string()) {
             return first_part["text"].get<std::string>();
           }
         }
@@ -222,9 +237,8 @@ std::string GoogleProvider::prompt(const std::string& model,
   std::string path = "/v1beta/models/" + model + ":generateContent";
 
   // Make HTTP request
-  HttpClient client;
   auto response =
-      client.post(get_endpoint(model), path, request_body, headers, 30);
+      HttpClient::post(get_endpoint(), path, request_body, headers, 30);
 
   // Check for network errors
   if (!response.error.empty()) {
@@ -242,7 +256,7 @@ std::string GoogleProvider::prompt(const std::string& model,
       *error = api_error;
     } else {
       *error = "HTTP " + std::to_string(response.status_code) + " - " +
-               response.body.substr(0, 100);
+               truncate_utf8(response.body, kMaxErrorBodyBytes);
     }
     return "";
   }
@@ -265,8 +279,7 @@ std::string GoogleProvider::embed(const std::string& model,
   std::string path = "/v1beta/models/" + model + ":embedContent";
 
   // Make HTTP request
-  HttpClient client;
-  auto response = client.post(get_endpoint(model), path, request_body, headers, 30);
+  auto response = HttpClient::post(get_endpoint(), path, request_body, headers, 30);
 
   // Check for network errors
   if (!response.error.empty()) {
@@ -287,11 +300,11 @@ std::string GoogleProvider::embed(const std::string& model,
         }
       } else {
         *error = "HTTP " + std::to_string(response.status_code) + " - " +
-                 response.body.substr(0, 100);
+                 truncate_utf8(response.body, kMaxErrorBodyBytes);
       }
     } catch (const json::exception& e) {
       *error = "HTTP " + std::to_string(response.status_code) + " - " +
-               response.body.substr(0, 100);
+               truncate_utf8(response.body, kMaxErrorBodyBytes);
     }
     return "";
   }
@@ -310,17 +323,22 @@ std::string GoogleProvider::embed(const std::string& model,
       return "";
     }
 
-    // Try new format first (gemini-embedding-2-preview)
-    if (response_json.contains("embeddings") &&
-        response_json["embeddings"].is_array() &&
-        !response_json["embeddings"].empty()) {
-      return response_json["embeddings"][0]["values"].dump();
+    // Try new format first (gemini-embedding-2-preview). Bind through a const
+    // reference: on a non-const json, operator[] inserts a null member for a
+    // missing key, which would dump as the string "null" and be returned as a
+    // successful embedding.
+    const json& const_response = response_json;
+    if (const_response.contains("embeddings") &&
+        const_response["embeddings"].is_array() &&
+        !const_response["embeddings"].empty() &&
+        const_response["embeddings"][0].contains("values")) {
+      return const_response["embeddings"][0]["values"].dump();
     }
 
     // Fall back to old format (gemini-embedding-001)
-    if (response_json.contains("embedding") &&
-        response_json["embedding"].contains("values")) {
-      return response_json["embedding"]["values"].dump();
+    if (const_response.contains("embedding") &&
+        const_response["embedding"].contains("values")) {
+      return const_response["embedding"]["values"].dump();
     }
 
     *error = "Invalid response format: missing embedding values";
@@ -336,9 +354,6 @@ std::string GoogleProvider::embed(const std::string& model,
 // OpenAIProvider Implementation
 // =============================================================================
 
-OpenAIProvider::OpenAIProvider() {}
-
-OpenAIProvider::~OpenAIProvider() {}
 
 std::string OpenAIProvider::get_endpoint() const {
   return "https://api.openai.com";
@@ -377,8 +392,11 @@ std::string OpenAIProvider::parse_response(const std::string& response_json,
     if (response.contains("choices") && response["choices"].is_array() &&
         !response["choices"].empty()) {
       const auto& first_choice = response["choices"][0];
+      // content is null on refusals and tool-call responses, so check the
+      // type rather than only its presence.
       if (first_choice.contains("message") &&
-          first_choice["message"].contains("content")) {
+          first_choice["message"].contains("content") &&
+          first_choice["message"]["content"].is_string()) {
         return first_choice["message"]["content"].get<std::string>();
       }
     }
@@ -401,9 +419,8 @@ std::string OpenAIProvider::prompt(const std::string& model,
   auto headers = get_headers(api_key);
 
   // Make HTTP request
-  HttpClient client;
   auto response =
-      client.post(get_endpoint(), "/v1/chat/completions", request_body,
+      HttpClient::post(get_endpoint(), "/v1/chat/completions", request_body,
                   headers, 30);
 
   // Check for network errors
@@ -422,7 +439,7 @@ std::string OpenAIProvider::prompt(const std::string& model,
       *error = api_error;
     } else {
       *error = "HTTP " + std::to_string(response.status_code) + " - " +
-               response.body.substr(0, 100);
+               truncate_utf8(response.body, kMaxErrorBodyBytes);
     }
     return "";
   }
@@ -442,9 +459,8 @@ std::string OpenAIProvider::embed(const std::string& model,
   auto headers = get_headers(api_key);
 
   // Make HTTP request
-  HttpClient client;
   auto response =
-      client.post(get_endpoint(), "/v1/embeddings", request_body, headers, 30);
+      HttpClient::post(get_endpoint(), "/v1/embeddings", request_body, headers, 30);
 
   // Check for network errors
   if (!response.error.empty()) {
@@ -465,11 +481,11 @@ std::string OpenAIProvider::embed(const std::string& model,
         }
       } else {
         *error = "HTTP " + std::to_string(response.status_code) + " - " +
-                 response.body.substr(0, 100);
+                 truncate_utf8(response.body, kMaxErrorBodyBytes);
       }
     } catch (const json::exception& e) {
       *error = "HTTP " + std::to_string(response.status_code) + " - " +
-               response.body.substr(0, 100);
+               truncate_utf8(response.body, kMaxErrorBodyBytes);
     }
     return "";
   }
@@ -517,9 +533,6 @@ namespace {
 constexpr int kLocalTimeoutSeconds = 300;
 }
 
-LocalProvider::LocalProvider() {}
-
-LocalProvider::~LocalProvider() {}
 
 std::string LocalProvider::get_endpoint() const {
   return "http://127.0.0.1:11434";
@@ -564,15 +577,19 @@ std::string LocalProvider::parse_response(const std::string& response_json,
     if (response.contains("choices") && response["choices"].is_array() &&
         !response["choices"].empty()) {
       const auto& first_choice = response["choices"][0];
+      // content is null on refusals and tool-call responses, so check the
+      // type rather than only its presence.
       if (first_choice.contains("message") &&
-          first_choice["message"].contains("content")) {
+          first_choice["message"].contains("content") &&
+          first_choice["message"]["content"].is_string()) {
         return first_choice["message"]["content"].get<std::string>();
       }
     }
 
     // Fall back to Ollama native format: message.content
     if (response.contains("message") &&
-        response["message"].contains("content")) {
+        response["message"].contains("content") &&
+        response["message"]["content"].is_string()) {
       return response["message"]["content"].get<std::string>();
     }
 
@@ -595,8 +612,7 @@ std::string LocalProvider::prompt(const std::string& model,
 
   // Use Ollama's native chat endpoint rather than the OpenAI-compatible
   // one so thinking can be disabled via the "think" request option.
-  HttpClient client;
-  auto response = client.post(get_endpoint(), "/api/chat", request_body,
+  auto response = HttpClient::post(get_endpoint(), "/api/chat", request_body,
                               headers, kLocalTimeoutSeconds);
 
   // Check for network errors
@@ -614,7 +630,7 @@ std::string LocalProvider::prompt(const std::string& model,
       *error = api_error;
     } else {
       *error = "HTTP " + std::to_string(response.status_code) + " - " +
-               response.body.substr(0, 100);
+               truncate_utf8(response.body, kMaxErrorBodyBytes);
     }
     return "";
   }
@@ -634,8 +650,7 @@ std::string LocalProvider::embed(const std::string& model,
   auto headers = get_headers();
 
   // Make HTTP request
-  HttpClient client;
-  auto response = client.post(get_endpoint(), "/v1/embeddings", request_body,
+  auto response = HttpClient::post(get_endpoint(), "/v1/embeddings", request_body,
                               headers, kLocalTimeoutSeconds);
 
   // Check for network errors
@@ -658,11 +673,11 @@ std::string LocalProvider::embed(const std::string& model,
         }
       } else {
         *error = "HTTP " + std::to_string(response.status_code) + " - " +
-                 response.body.substr(0, 100);
+                 truncate_utf8(response.body, kMaxErrorBodyBytes);
       }
     } catch (const json::exception& e) {
       *error = "HTTP " + std::to_string(response.status_code) + " - " +
-               response.body.substr(0, 100);
+               truncate_utf8(response.body, kMaxErrorBodyBytes);
     }
     return "";
   }

--- a/src/ai_providers.cc
+++ b/src/ai_providers.cc
@@ -46,6 +46,35 @@ std::string truncate_utf8(const std::string& text, size_t max_bytes) {
   return std::string(truncate_utf8_view(text, max_bytes));
 }
 
+namespace {
+
+// Turn an upstream `error` member into text. The shape is not guaranteed:
+// Anthropic, Google and OpenAI nest {"error": {"message": "..."}}, Ollama also
+// sends {"error": "..."}, and any of them can send a "message" that is not a
+// string (an object, an array, a number) — .get<std::string>() would throw
+// type_error.302 on those, which the caller reports as a bogus "JSON parse
+// error". Only a string is read as text; anything else is dumped verbatim so
+// the message still carries what the provider said.
+//
+// dump() uses the replacing error handler because the error path must not
+// throw: a body with invalid UTF-8 would otherwise mask the real failure.
+std::string extract_error_message(const json& error_node) {
+  if (error_node.is_string()) {
+    return error_node.get<std::string>();
+  }
+
+  if (error_node.is_object()) {
+    auto message = error_node.find("message");
+    if (message != error_node.end() && message->is_string()) {
+      return message->get<std::string>();
+    }
+  }
+
+  return error_node.dump(-1, ' ', false, json::error_handler_t::replace);
+}
+
+}  // namespace
+
 // =============================================================================
 // AnthropicProvider Implementation
 // =============================================================================
@@ -78,11 +107,7 @@ std::string AnthropicProvider::parse_response(const std::string& response_json,
 
     // Check for API error
     if (response.contains("error")) {
-      if (response["error"].contains("message")) {
-        *error = response["error"]["message"].get<std::string>();
-      } else {
-        *error = response["error"].dump();
-      }
+      *error = extract_error_message(response["error"]);
       return "";
     }
 
@@ -192,11 +217,7 @@ std::string GoogleProvider::parse_response(const std::string& response_json,
 
     // Check for API error
     if (response.contains("error")) {
-      if (response["error"].contains("message")) {
-        *error = response["error"]["message"].get<std::string>();
-      } else {
-        *error = response["error"].dump();
-      }
+      *error = extract_error_message(response["error"]);
       return "";
     }
 
@@ -293,11 +314,7 @@ std::string GoogleProvider::embed(const std::string& model,
     try {
       auto error_response = json::parse(response.body);
       if (error_response.contains("error")) {
-        if (error_response["error"].contains("message")) {
-          *error = error_response["error"]["message"].get<std::string>();
-        } else {
-          *error = error_response["error"].dump();
-        }
+        *error = extract_error_message(error_response["error"]);
       } else {
         *error = "HTTP " + std::to_string(response.status_code) + " - " +
                  truncate_utf8(response.body, kMaxErrorBodyBytes);
@@ -315,11 +332,7 @@ std::string GoogleProvider::embed(const std::string& model,
 
     // Check for API error
     if (response_json.contains("error")) {
-      if (response_json["error"].contains("message")) {
-        *error = response_json["error"]["message"].get<std::string>();
-      } else {
-        *error = response_json["error"].dump();
-      }
+      *error = extract_error_message(response_json["error"]);
       return "";
     }
 
@@ -380,11 +393,7 @@ std::string OpenAIProvider::parse_response(const std::string& response_json,
 
     // Check for API error
     if (response.contains("error")) {
-      if (response["error"].contains("message")) {
-        *error = response["error"]["message"].get<std::string>();
-      } else {
-        *error = response["error"].dump();
-      }
+      *error = extract_error_message(response["error"]);
       return "";
     }
 
@@ -474,11 +483,7 @@ std::string OpenAIProvider::embed(const std::string& model,
     try {
       auto error_response = json::parse(response.body);
       if (error_response.contains("error")) {
-        if (error_response["error"].contains("message")) {
-          *error = error_response["error"]["message"].get<std::string>();
-        } else {
-          *error = error_response["error"].dump();
-        }
+        *error = extract_error_message(error_response["error"]);
       } else {
         *error = "HTTP " + std::to_string(response.status_code) + " - " +
                  truncate_utf8(response.body, kMaxErrorBodyBytes);
@@ -496,11 +501,7 @@ std::string OpenAIProvider::embed(const std::string& model,
 
     // Check for API error
     if (response_json.contains("error")) {
-      if (response_json["error"].contains("message")) {
-        *error = response_json["error"]["message"].get<std::string>();
-      } else {
-        *error = response_json["error"].dump();
-      }
+      *error = extract_error_message(response_json["error"]);
       return "";
     }
 
@@ -563,13 +564,7 @@ std::string LocalProvider::parse_response(const std::string& response_json,
 
     // Check for API error
     if (response.contains("error")) {
-      if (response["error"].is_string()) {
-        *error = response["error"].get<std::string>();
-      } else if (response["error"].contains("message")) {
-        *error = response["error"]["message"].get<std::string>();
-      } else {
-        *error = response["error"].dump();
-      }
+      *error = extract_error_message(response["error"]);
       return "";
     }
 
@@ -664,13 +659,7 @@ std::string LocalProvider::embed(const std::string& model,
     try {
       auto error_response = json::parse(response.body);
       if (error_response.contains("error")) {
-        if (error_response["error"].is_string()) {
-          *error = error_response["error"].get<std::string>();
-        } else if (error_response["error"].contains("message")) {
-          *error = error_response["error"]["message"].get<std::string>();
-        } else {
-          *error = error_response["error"].dump();
-        }
+        *error = extract_error_message(error_response["error"]);
       } else {
         *error = "HTTP " + std::to_string(response.status_code) + " - " +
                  truncate_utf8(response.body, kMaxErrorBodyBytes);
@@ -688,13 +677,7 @@ std::string LocalProvider::embed(const std::string& model,
 
     // Check for API error
     if (response_json.contains("error")) {
-      if (response_json["error"].is_string()) {
-        *error = response_json["error"].get<std::string>();
-      } else if (response_json["error"].contains("message")) {
-        *error = response_json["error"]["message"].get<std::string>();
-      } else {
-        *error = response_json["error"].dump();
-      }
+      *error = extract_error_message(response_json["error"]);
       return "";
     }
 

--- a/src/ai_providers.h
+++ b/src/ai_providers.h
@@ -20,8 +20,19 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 
 namespace vsql_ai {
+
+// Shorten a UTF-8 string to at most max_bytes without splitting a multi-byte
+// sequence. Upstream provider errors are UTF-8 and frequently non-ASCII, so a
+// plain substr() can leave a truncated code point in a warning message.
+//
+// The view overload borrows from `text` and is the one to use on the result
+// path, where copying a response that already fits would be pure waste; the
+// caller must keep `text` alive for as long as the view is used.
+std::string_view truncate_utf8_view(std::string_view text, size_t max_bytes);
+std::string truncate_utf8(const std::string& text, size_t max_bytes);
 
 // Abstract base class for AI providers
 class AIProvider {
@@ -39,14 +50,15 @@ class AIProvider {
                             const std::string& api_key,
                             const std::string& text,
                             std::string* error) = 0;
+
+  // Whether a non-empty API key is required. Locally hosted providers do not
+  // authenticate, so the caller asks the provider rather than testing its name.
+  virtual bool requires_api_key() const { return true; }
 };
 
 // Anthropic Claude provider implementation
 class AnthropicProvider : public AIProvider {
  public:
-  AnthropicProvider();
-  ~AnthropicProvider() override;
-
   std::string prompt(const std::string& model, const std::string& api_key,
                      const std::string& prompt_text,
                      std::string* error) override;
@@ -67,9 +79,6 @@ class AnthropicProvider : public AIProvider {
 // Google provider implementation (Gemini models)
 class GoogleProvider : public AIProvider {
  public:
-  GoogleProvider();
-  ~GoogleProvider() override;
-
   std::string prompt(const std::string& model, const std::string& api_key,
                      const std::string& prompt_text,
                      std::string* error) override;
@@ -78,7 +87,7 @@ class GoogleProvider : public AIProvider {
                     const std::string& text, std::string* error) override;
 
  private:
-  std::string get_endpoint(const std::string& model) const;
+  std::string get_endpoint() const;
   std::map<std::string, std::string> get_headers(
       const std::string& api_key) const;
   std::string build_request_body(const std::string& prompt) const;
@@ -89,9 +98,6 @@ class GoogleProvider : public AIProvider {
 // OpenAI provider implementation (GPT models)
 class OpenAIProvider : public AIProvider {
  public:
-  OpenAIProvider();
-  ~OpenAIProvider() override;
-
   std::string prompt(const std::string& model, const std::string& api_key,
                      const std::string& prompt_text,
                      std::string* error) override;
@@ -112,15 +118,14 @@ class OpenAIProvider : public AIProvider {
 // Local provider implementation (Ollama on 127.0.0.1:11434)
 class LocalProvider : public AIProvider {
  public:
-  LocalProvider();
-  ~LocalProvider() override;
-
   std::string prompt(const std::string& model, const std::string& api_key,
                      const std::string& prompt_text,
                      std::string* error) override;
 
   std::string embed(const std::string& model, const std::string& api_key,
                     const std::string& text, std::string* error) override;
+
+  bool requires_api_key() const override { return false; }
 
  private:
   std::string get_endpoint() const;

--- a/src/http_client.cc
+++ b/src/http_client.cc
@@ -19,52 +19,16 @@
 
 #include "http_client.h"
 
-#include <regex>
-
 namespace vsql_ai {
-
-HttpClient::HttpClient() {}
-
-HttpClient::~HttpClient() {}
-
-bool HttpClient::parse_url(const std::string& url, std::string* scheme,
-                           std::string* host, int* port) {
-  // Parse URL using regex: (https?)://([^:/]+)(?::(\d+))?
-  std::regex url_regex(R"((https?)://([^:/]+)(?::(\d+))?)");
-  std::smatch match;
-
-  if (!std::regex_search(url, match, url_regex)) {
-    return false;
-  }
-
-  *scheme = match[1].str();
-  *host = match[2].str();
-
-  if (match[3].matched) {
-    *port = std::stoi(match[3].str());
-  } else {
-    *port = (*scheme == "https") ? 443 : 80;
-  }
-
-  return true;
-}
 
 HttpClient::Response HttpClient::post(
     const std::string& url, const std::string& path, const std::string& body,
     const std::map<std::string, std::string>& headers, int timeout_seconds) {
   Response response;
-  response.status_code = 0;
-
-  // Parse URL
-  std::string scheme, host;
-  int port;
-  if (!parse_url(url, &scheme, &host, &port)) {
-    response.error = "Invalid URL format";
-    return response;
-  }
 
   try {
-    // Create HTTP client
+    // Create HTTP client. httplib parses the URL itself; there is no need to
+    // split out scheme/host/port here.
     httplib::Client cli(url);
 
     // Set timeouts
@@ -82,52 +46,16 @@ HttpClient::Response HttpClient::post(
     auto res = cli.Post(path, http_headers, body, "application/json");
 
     if (!res) {
-      // Connection failed
-      auto err = res.error();
-      switch (err) {
-        case httplib::Error::Connection:
-          response.error = "Connection failed";
-          break;
-        case httplib::Error::BindIPAddress:
-          response.error = "Failed to bind IP address";
-          break;
-        case httplib::Error::Read:
-          response.error = "Read error";
-          break;
-        case httplib::Error::Write:
-          response.error = "Write error";
-          break;
-        case httplib::Error::ExceedRedirectCount:
-          response.error = "Too many redirects";
-          break;
-        case httplib::Error::Canceled:
-          response.error = "Request canceled";
-          break;
-        case httplib::Error::SSLConnection:
-          response.error = "SSL connection failed";
-          break;
-        case httplib::Error::SSLLoadingCerts:
-          response.error = "Failed to load SSL certificates";
-          break;
-        case httplib::Error::SSLServerVerification:
-          response.error = "SSL server verification failed";
-          break;
-        case httplib::Error::UnsupportedMultipartBoundaryChars:
-          response.error = "Unsupported multipart boundary characters";
-          break;
-        case httplib::Error::Compression:
-          response.error = "Compression error";
-          break;
-        default:
-          response.error = "Unknown error";
-          break;
-      }
+      // No HTTP exchange took place. Use httplib's own mapping so newer error
+      // kinds (notably Timeout and ConnectionTimeout, the likely outcome on
+      // the 300-second local path) are reported instead of "Unknown error".
+      response.error = httplib::to_string(res.error());
       return response;
     }
 
     // Success (HTTP response received, even if status >= 400)
     response.status_code = res->status;
-    response.body = res->body;
+    response.body = std::move(res->body);
     // Don't set error here - let the caller handle HTTP status codes
     // and parse the response body for detailed error messages
 

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -25,18 +25,17 @@ namespace vsql_ai {
 class HttpClient {
  public:
   // Exactly one of two outcomes holds:
-  //   transport_failed()  - no HTTP exchange happened; `error` says why and
-  //                         `status_code` is 0.
-  //   otherwise           - a response was received; `status_code` and `body`
-  //                         are valid and `error` is empty even for 4xx/5xx,
-  //                         so the caller can parse the body for a provider
-  //                         error message.
+  //   `error` non-empty - no HTTP exchange happened; `error` says why and
+  //                       `status_code` is 0.
+  //   `error` empty     - a response was received; `status_code` and `body`
+  //                       are valid, and `error` stays empty even for 4xx/5xx
+  //                       so the caller can parse the body for a provider
+  //                       error message.
   struct Response {
     int status_code = 0;
     std::string body;
     std::string error;
 
-    bool transport_failed() const { return status_code == 0; }
     bool is_success() const { return status_code >= 200 && status_code < 300; }
   };
 

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -24,27 +24,27 @@ namespace vsql_ai {
 
 class HttpClient {
  public:
+  // Exactly one of two outcomes holds:
+  //   transport_failed()  - no HTTP exchange happened; `error` says why and
+  //                         `status_code` is 0.
+  //   otherwise           - a response was received; `status_code` and `body`
+  //                         are valid and `error` is empty even for 4xx/5xx,
+  //                         so the caller can parse the body for a provider
+  //                         error message.
   struct Response {
-    int status_code;
+    int status_code = 0;
     std::string body;
     std::string error;
 
+    bool transport_failed() const { return status_code == 0; }
     bool is_success() const { return status_code >= 200 && status_code < 300; }
   };
 
-  HttpClient();
-  ~HttpClient();
-
-  // Make a POST request
-  Response post(const std::string& url, const std::string& path,
-                const std::string& body,
-                const std::map<std::string, std::string>& headers,
-                int timeout_seconds = 30);
-
- private:
-  // Helper to extract host from URL
-  static bool parse_url(const std::string& url, std::string* scheme,
-                        std::string* host, int* port);
+  // Make a POST request. Stateless — no instance required.
+  static Response post(const std::string& url, const std::string& path,
+                       const std::string& body,
+                       const std::map<std::string, std::string>& headers,
+                       int timeout_seconds);
 };
 
 }  // namespace vsql_ai


### PR DESCRIPTION
Findings from a full code review of the current `main` (the extended-thinking, timeout, and Ollama `/api/chat` changes from #22/#23/#26). Every fix below is verified by execution, not inspection alone.

## Server crash — the reason this PR exists

Neither VDF entry point had a `try`/`catch`, and the SDK does not wrap VDF calls (checked `detail/vef_register.h`, `detail/func_builder.h`, `vsql/func_builder.h` in SDK 0.0.5-dev). `nlohmann::json::dump()` throws `type_error.316` on input that is not valid UTF-8 — reachable from ordinary SQL:

```sql
SELECT ai_prompt('local', 'llama3.2', '', CONVERT(0xFF USING latin1));
```

Before: exception crosses the C ABI → `std::terminate` → server down.
After: `NULL` + `Warning 3200 ... invalid UTF-8 byte at index 0: 0xFF`, server unaffected. Regression test added.

`report_exception()` has its own nested try, so building the message cannot throw out of the boundary either. `noexcept` would be the natural way to have the compiler enforce this, but `make_func`'s `FuncParamTypes` has no specialization for noexcept function types and registration fails to compile — a source comment records why it is absent.

## Provider parsing bugs

- **`ai_embedding` could return the literal string `"null"` as a success.** Google's newer response shape was read with `["values"]` on a non-const `json`; nlohmann *inserts* a missing key and `dump()` renders it. Flagged independently by three reviewers.
- **`"content": null` threw.** OpenAI returns it for refusals and tool-call responses; `.get<std::string>()` ran with no `is_string()` guard, surfacing as "JSON parse error".
- **Timeouts reported as `"Unknown error"`.** The hand-written `httplib::Error` switch omitted `Timeout` and `ConnectionTimeout` — the most likely failure on the 300 s local path. Now uses `httplib::to_string()`.

## Output and error text

- UTF-8-aware truncation everywhere, including the two `"Unknown provider: …"` warnings that bypassed it and were then cut mid-sequence by the SDK's byte-wise 511-byte clamp. Verified: `ai_prompt(REPEAT('é',400), …)` now ends on a complete code point.
- `ai_prompt` trims the response on a code point boundary; `ai_embedding` refuses an oversized vector rather than returning a clipped array that parses as a shorter one.

## Cleanups

`requires_api_key()` replaces the hardcoded `!= "local"` and runs after provider lookup — `ai_prompt('gogle','m','','hi')` now reports the typo instead of a missing key. Dead `parse_url` and its per-call `std::regex` deleted (outputs were never read; httplib re-parses the URL). `HttpClient::post` made static. Empty ctor/dtor pairs, dead locals, dead includes removed.

## Tests

`error_handling.test` asserted `IS NOT NULL` on paths where `out.warning()` yields NULL — the recorded results were all `0` while the aliases (`has_result`, `empty_provider_result`) and comments claimed the opposite. Re-expressed as `IS NULL`, renamed, re-recorded. The suite stays network-free: every statement in it is rejected before any HTTP call, so CI passes with no Ollama and no keys.

## Docs

The README's "Using Embeddings with Table Data" example **did not work** — `ai_embedding()` output carries the binary character set, so inserting it into a `JSON` column fails with `ERROR 3144`. Rewritten to show the failure and the `CONVERT(... USING utf8mb4)` fix. Added a Known Limitations section (blocking per-row I/O, the charset constraint, no Anthropic embeddings, warning truncation, warnings-not-errors).

## Verification

- Full MTR suite **9/9** against live Anthropic, Google, OpenAI and Ollama.
- 19 acceptance criteria, all passing, including that every Anthropic model ID the README advertises is accepted by the live API.
- Targeted probes for each behavior change (invalid UTF-8, provider-name ordering, non-ASCII truncation).

## Known open, deliberately not fixed here

In the four prompt paths, a non-2xx body that is not valid JSON (proxy HTML 502, empty 504) sets the error to `"JSON parse error: …"`, so the `HTTP <status> - <body>` fallback is unreachable and the status code is never shown. The three embed paths handle this correctly. The clean fix is an `extract_api_error()` helper that also collapses seven duplicated post-request blocks — a refactor rather than a review fix, so it is left for its own PR. Same for an upstream `{"error":{"message":""}}` being treated as a successful empty response.

Also deferred, with reasons: unifying the seven-times-duplicated transport block, collapsing the two near-identical entry-point bodies, and a `thread_local` connection cache (which would save a TLS handshake per row but needs its own concurrency review).

> [!NOTE]
> Stacked on `main`, not on #29. Both touch `README.md` but in different sections; #29 updates the model list, this updates the embedding examples and adds Known Limitations. Merge order shouldn't matter, but #29 first is the cleaner sequence since the 0.0.5 release is gated on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)