### PR TITLE
docs: fix macOS mysql-test path and VEB var

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ A powerful AI extension for VillageSQL Server that adds AI prompt capabilities a
 
 ## Installation
 
+If you installed VillageSQL with the install script, the Docker image, or a
+release tarball, `vsql_ai.veb` is already in the server's `lib/veb/`
+directory — this extension is bundled with the server. There is nothing to build
+or download:
+
+```sql
+INSTALL EXTENSION vsql_ai;
+```
+
+Build from source only if you built the server from source without the bundled
+extensions, or if you are working on this extension itself.
+
 ### Build from Source
 
 #### Prerequisites
@@ -44,14 +56,14 @@ A powerful AI extension for VillageSQL Server that adds AI prompt capabilities a
    ```bash
    mkdir -p build
    cd build
-   cmake .. -DVillageSQL_BUILD_DIR=~/build/villagesql
+   cmake .. -DVillageSQL_BUILD_DIR="$HOME/build/villagesql"
    ```
 
    **Note**: `VillageSQL_BUILD_DIR` should point to your VillageSQL build directory.
 
 3. Build the extension:
    ```bash
-   make -j $(($(getconf _NPROCESSORS_ONLN) - 2))
+   make -j $(getconf _NPROCESSORS_ONLN)
    ```
 
    This creates the `veb` package in the build directory.
@@ -61,7 +73,7 @@ A powerful AI extension for VillageSQL Server that adds AI prompt capabilities a
    make install
    ```
 
-   This copies the VEB to the directory specified by `VEB_INSTALL_DIR`. If not using `make install`, you can manually copy the VEB file to your desired location.
+   This copies the VEB to the directory specified by `VillageSQL_VEB_INSTALL_DIR`. If not using `make install`, you can manually copy the VEB file to your desired location.
 
 ## Usage
 
@@ -417,8 +429,8 @@ VSQL_AI_VEB=/path/to/vsql-ai/build/vsql_ai.veb \
 
 **macOS:**
 ```bash
-cd ~/build/mysql-test
-VSQL_AI_VEB=/path/to/vsql-ai/build/veb \
+cd ~/build/villagesql/mysql-test
+VSQL_AI_VEB=/path/to/vsql-ai/build/vsql_ai.veb \
   perl mysql-test-run.pl --suite=/path/to/vsql-ai/mysql-test
 ```
 


### PR DESCRIPTION
The macOS test block pointed at a directory that does not exist and named the
wrong VEB filename. The Linux block three lines above it was correct, so only the
macOS path was broken. Fixed to the path every other cd in the file uses, plus
the VEB install variable CMakeLists.txt actually reads, and the tilde and make -j
build fixes.

The README also opened straight into a source build. vsql_ai is bundled with the
server, so after an install-script, Docker or tarball install the veb is already
in lib/veb/ and INSTALL EXTENSION is all you need; building is the fallback for
a server built without the bundled extensions.

Verified after rebuilding this extension from origin/main and reinstalling, and
by installing from the bundled veb. The bundle in the build tree was two versions
behind, so checking against it would have described older code.

AI=CLAUDE
